### PR TITLE
build: update CMake config for C++17 and macOS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(dagtdep)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS False)
+
 add_subdirectory(src)
 add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,10 @@ add_definitions(${LLVM_DEFINITIONS_LIST})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(APPLE)
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -undefined dynamic_lookup")
+endif()
+
 # Add subdirectories for each module
 add_subdirectory(DavioDecomposition)
 add_subdirectory(Function)


### PR DESCRIPTION
Dear Sir,

This PR includes a couple of quick CMake configuration tweaks to improve our build stability, especially for macOS users.

**What changed:**
1. **Global C++17 Enforcement:** I've explicitly set the C++ standard to C++17 globally in the root `CMakeLists.txt` and disabled compiler extensions (`CMAKE_CXX_EXTENSIONS False`). This ensures we stick closely to the standard and avoid compiler-specific quirks.
2. **macOS Linking Fix:** Added the `-undefined dynamic_lookup` linker flag for Apple systems in [src/CMakeLists.txt]. This allows symbols to be resolved at runtime on macOS, which prevents the build from failing due to undefined symbols.