### PR TITLE
feat: implement Existing Method and Proposed Method synthesis algorithms

### DIFF
--- a/doc/SPEC.md
+++ b/doc/SPEC.md
@@ -17,8 +17,8 @@ All modules are implemented as dynamically loadable LLVM passes that can be used
 
 ## XAG
 
-XAG implements the algorithm in Meuli et al [2022](https://doi.org/10.1038/s41534-021-00514-y) to optimize
-XAG for AND depth, which optimizes for T-depth. These are implemented in the [caterpillar library](https://github.com/gmeuli/caterpillar)
+XAG implements the Meuli low-depth strategy from [Meuli et al. 2022](https://doi.org/10.1038/s41534-021-00514-y) to optimize
+XAG for AND depth, which optimizes for T-depth. This is implemented in the [caterpillar library](https://github.com/gmeuli/caterpillar)
 
 Inputs and Outputs from this module will be in mockturtle::xag_network format that caterpillar uses
 

--- a/include/QC.h
+++ b/include/QC.h
@@ -10,13 +10,21 @@
 
 namespace xagtdep {
 
+/// Algorithm selection for quantum circuit synthesis.
+enum class SynthesisAlgorithm {
+  Current,        // Original XAGToGateList (Toffoli-based)
+  ExistingMethod, // Algorithm 1: exact Toffoli decomposition, compute||uncompute
+  ProposedMethod  // Algorithm 2: relative-phase Toffoli, no top-level uncompute
+};
+
 /// Core algorithm class: consumes the XagContext produced by XAGPass
 /// and synthesizes a quantum circuit.
 /// This is what QCTest exercises directly.
 class QC {
 public:
   /// Traverse ctx.xag, build a gate list, and (optionally) produce QASM.
-  void evaluate(const XagContext &ctx);
+  void evaluate(const XagContext &ctx,
+                SynthesisAlgorithm algo = SynthesisAlgorithm::Current);
 
   /// Access the output (QASM string when Python enabled, JSON gate list
   /// otherwise).

--- a/include/QCGateList.h
+++ b/include/QCGateList.h
@@ -10,7 +10,7 @@
 
 namespace xagtdep {
 
-enum class GateType { X, CNOT, Toffoli };
+enum class GateType { X, CNOT, Toffoli, H, T, Tdg };
 
 struct GateOp {
   GateType type;
@@ -44,6 +44,15 @@ struct QCGateList {
         break;
       case GateType::Toffoli:
         json += "ccx";
+        break;
+      case GateType::H:
+        json += "h";
+        break;
+      case GateType::T:
+        json += "t";
+        break;
+      case GateType::Tdg:
+        json += "tdg";
         break;
       }
       json += "\",\"controls\":[";

--- a/src/QC/CMakeLists.txt
+++ b/src/QC/CMakeLists.txt
@@ -6,6 +6,8 @@ option(XAGTDEP_ENABLE_PYTHON "Enable Qiskit Python integration for QASM output" 
 set(QC_SOURCES
     QC.cpp
     XAGToGateList.cpp
+    ExistingMethod.cpp
+    ProposedMethod.cpp
 )
 
 if(XAGTDEP_ENABLE_PYTHON)

--- a/src/QC/ExistingMethod.cpp
+++ b/src/QC/ExistingMethod.cpp
@@ -1,0 +1,346 @@
+// ExistingMethod.cpp — Algorithm 1 ("Existing Method") implementation.
+//
+// Recursive depth-first XAG traversal producing quantum gates per:
+//   XOR node  → Fig 5  (two CNOTs into output qubit)
+//   AND node  → Fig 6  (CC-iZ decomposition, both inputs PI)
+//              → Fig 1  (AND at overall output, with A/A† and CC-Z)
+//              → Fig 11 (one input PI, with F sub-circuit and CC-iZ)
+//
+// Top-level: QC = compute || uncompute (adjoint of compute appended).
+
+#include "ExistingMethod.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace xagtdep;
+
+ExistingMethod::ExistingMethod(const mockturtle::xag_network &xag)
+    : xag_(xag) {}
+
+QCGateList ExistingMethod::translate(const XagContext &ctx) {
+  ExistingMethod t(ctx.xag);
+
+  // Assign qubits 0..num_pis-1 to primary inputs.
+  ctx.xag.foreach_pi(
+      [&](auto node) { t.node_to_qubit_[ctx.xag.node_to_index(node)] = t.next_qubit_++; });
+  t.result_.num_pis = ctx.xag.num_pis();
+
+  // Build set of PO node indices for isOutputNode detection.
+  ctx.xag.foreach_po([&](auto signal) {
+    t.po_nodes_.insert(ctx.xag.node_to_index(ctx.xag.get_node(signal)));
+  });
+
+  // Compute phase: process each primary output.
+  ctx.xag.foreach_po([&](auto signal) { t.processSignal(signal); });
+
+  size_t computeEnd = t.result_.gates.size();
+
+  // Uncompute phase: append adjoint of entire compute circuit.
+  t.appendAdjoint(0, computeEnd);
+
+  t.result_.num_qubits = t.next_qubit_;
+  t.result_.num_ancillas = t.next_qubit_ - ctx.xag.num_pis();
+
+  return t.result_;
+}
+
+// ── Recursive traversal ──────────────────────────────────────────────────
+
+uint32_t ExistingMethod::processSignal(mockturtle::xag_network::signal sig) {
+  auto node = xag_.get_node(sig);
+  bool complemented = xag_.is_complemented(sig);
+  uint32_t qubit = processNode(node);
+  if (complemented)
+    emitGate(GateType::X, {}, qubit);
+  return qubit;
+}
+
+uint32_t ExistingMethod::processNode(mockturtle::xag_network::node node) {
+  uint32_t idx = xag_.node_to_index(node);
+
+  auto it = node_to_qubit_.find(idx);
+  if (it != node_to_qubit_.end())
+    return it->second;
+
+  if (idx == 0) {
+    uint32_t qubit = next_qubit_++;
+    node_to_qubit_[idx] = qubit;
+    return qubit;
+  }
+
+  if (xag_.is_pi(node))
+    return node_to_qubit_[idx];
+
+  if (xag_.is_and(node))
+    return processAndNode(node);
+
+  return processXorNode(node);
+}
+
+// ── Fig 5: XOR node ──────────────────────────────────────────────────────
+// Sub-circuits B then A, each CNOT their output into a fresh output qubit.
+
+uint32_t ExistingMethod::processXorNode(mockturtle::xag_network::node node) {
+  std::vector<mockturtle::xag_network::signal> fanins;
+  xag_.foreach_fanin(node, [&](auto sig) { fanins.push_back(sig); });
+
+  uint32_t q_b = processSignal(fanins[0]);
+  uint32_t q_a = processSignal(fanins[1]);
+
+  uint32_t q_out = next_qubit_++;
+  emitGate(GateType::CNOT, {q_b}, q_out);
+  emitGate(GateType::CNOT, {q_a}, q_out);
+
+  node_to_qubit_[xag_.node_to_index(node)] = q_out;
+  return q_out;
+}
+
+// ── AND node router ──────────────────────────────────────────────────────
+
+uint32_t ExistingMethod::processAndNode(mockturtle::xag_network::node node) {
+  std::vector<mockturtle::xag_network::signal> fanins;
+  xag_.foreach_fanin(node, [&](auto sig) { fanins.push_back(sig); });
+
+  auto child0 = xag_.get_node(fanins[0]);
+  auto child1 = xag_.get_node(fanins[1]);
+  bool simple0 = isSimpleNode(child0);
+  bool simple1 = isSimpleNode(child1);
+
+  if (simple0 && simple1) {
+    // Case 1: Both inputs are primary inputs / already on qubits → Fig 6
+    uint32_t q_a = processSignal(fanins[0]);
+    uint32_t q_b = processSignal(fanins[1]);
+    return emitAndBothPI(node, q_a, q_b);
+  }
+
+  if (isOutputNode(node)) {
+    // Case 2: Node output is overall output → Fig 1
+    return emitAndOutput(node, fanins);
+  }
+
+  if (simple0 || simple1) {
+    // Case 3: One input is PI, other is sub-circuit → Fig 11
+    return emitAndOnePI(node, fanins);
+  }
+
+  // Case 4: Both complex → error
+  llvm::errs() << "[ExistingMethod] ERROR: both AND children are complex "
+                  "sub-circuits (unsupported)\n";
+  uint32_t q_err = next_qubit_++;
+  node_to_qubit_[xag_.node_to_index(node)] = q_err;
+  return q_err;
+}
+
+// ── Fig 6: AND both PI (CC-iZ decomposition) ────────────────────────────
+// Both inputs already on qubits. Allocate ancilla, apply CC-iZ.
+// 3 wires: q_a (ctrl), q_b (ctrl), a_out (target ancilla).
+
+uint32_t ExistingMethod::emitAndBothPI(mockturtle::xag_network::node node,
+                                       uint32_t q_a, uint32_t q_b) {
+  uint32_t a_out = next_qubit_++;
+  node_to_qubit_[xag_.node_to_index(node)] = a_out;
+
+  // The AND output ancilla needs H to go from |0⟩ to |+⟩, then CC-iZ,
+  // then H back. This implements the Toffoli-like AND gate.
+  emitGate(GateType::H, {}, a_out);
+  emitCCiZ(q_a, q_b, a_out);
+  emitGate(GateType::H, {}, a_out);
+
+  return a_out;
+}
+
+// ── Fig 1: AND output case ───────────────────────────────────────────────
+// Node output is a primary output. Uses A/A† sub-circuits with controlled
+// phase gates and ancilla.
+//
+// Wires: [A sub-circuit wires], B (PI), a_i (ancilla), |0⟩ (ancilla)
+// Sequence:
+//   1. H on |0⟩
+//   2. CC-iZ(B, |0⟩, a_i)   — controlled phase
+//   3. Compute A sub-circuit
+//   4. CNOT(A_output, a_i)
+//   5. CC-iZ†(B, |0⟩, a_i)  — controlled phase adjoint
+//   6. A† sub-circuit (uncompute A)
+//   7. H on |0⟩
+//   8. CNOT(|0⟩, a_i)
+
+uint32_t ExistingMethod::emitAndOutput(
+    mockturtle::xag_network::node node,
+    std::vector<mockturtle::xag_network::signal> &fanins) {
+  auto child0 = xag_.get_node(fanins[0]);
+  auto child1 = xag_.get_node(fanins[1]);
+  bool simple0 = isSimpleNode(child0);
+
+  // Identify which child is the PI (B) and which is the sub-circuit (A).
+  int piIdx = simple0 ? 0 : 1;
+  int complexIdx = 1 - piIdx;
+
+  uint32_t q_b = processSignal(fanins[piIdx]); // B — primary input
+
+  // Allocate ancilla qubits.
+  uint32_t a_i = next_qubit_++;   // a_i — AND output ancilla
+  uint32_t q_zero = next_qubit_++; // |0⟩ — helper ancilla
+
+  node_to_qubit_[xag_.node_to_index(node)] = a_i;
+
+  // 1. H on |0⟩
+  emitGate(GateType::H, {}, q_zero);
+
+  // 2. CC-iZ(B, |0⟩, a_i)
+  emitCCiZ(q_b, q_zero, a_i);
+
+  // 3. Compute A sub-circuit
+  size_t computeStart = result_.gates.size();
+  uint32_t q_a = processSignal(fanins[complexIdx]);
+  size_t computeEnd = result_.gates.size();
+
+  // 4. CNOT(A_output, a_i)
+  emitGate(GateType::CNOT, {q_a}, a_i);
+
+  // 5. CC-iZ†(B, |0⟩, a_i)
+  emitCCiZdg(q_b, q_zero, a_i);
+
+  // 6. A† (uncompute A sub-circuit)
+  appendAdjoint(computeStart, computeEnd);
+
+  // 7. H on |0⟩
+  emitGate(GateType::H, {}, q_zero);
+
+  // 8. CNOT(|0⟩, a_i)
+  emitGate(GateType::CNOT, {q_zero}, a_i);
+
+  return a_i;
+}
+
+// ── Fig 11: AND one PI case ──────────────────────────────────────────────
+// One input is PI (G), other requires sub-circuit (F).
+//
+// Wires: [F sub-circuit wires], G (PI), a_0 (ancilla), |0⟩ (ancilla)
+// Sequence:
+//   1. H on |0⟩
+//   2. CC-iZ(G, |0⟩, a_0)
+//   3. Compute F sub-circuit
+//   4. CNOT(F_output, a_0)
+//   5. CC-iZ†(G, |0⟩, a_0)
+//   6. H on |0⟩
+//   7. CNOT(|0⟩, a_0)
+
+uint32_t ExistingMethod::emitAndOnePI(
+    mockturtle::xag_network::node node,
+    std::vector<mockturtle::xag_network::signal> &fanins) {
+  auto child0 = xag_.get_node(fanins[0]);
+  auto child1 = xag_.get_node(fanins[1]);
+  bool simple0 = isSimpleNode(child0);
+
+  int piIdx = simple0 ? 0 : 1;
+  int complexIdx = 1 - piIdx;
+
+  uint32_t q_g = processSignal(fanins[piIdx]); // G — primary input
+
+  // Allocate ancilla qubits.
+  uint32_t a_0 = next_qubit_++;    // a_0 — AND output ancilla
+  uint32_t q_zero = next_qubit_++; // |0⟩ — helper ancilla
+
+  node_to_qubit_[xag_.node_to_index(node)] = a_0;
+
+  // 1. H on |0⟩
+  emitGate(GateType::H, {}, q_zero);
+
+  // 2. CC-iZ(G, |0⟩, a_0)
+  emitCCiZ(q_g, q_zero, a_0);
+
+  // 3. Compute F sub-circuit
+  uint32_t q_f = processSignal(fanins[complexIdx]);
+
+  // 4. CNOT(F_output, a_0)
+  emitGate(GateType::CNOT, {q_f}, a_0);
+
+  // 5. CC-iZ†(G, |0⟩, a_0)
+  emitCCiZdg(q_g, q_zero, a_0);
+
+  // 6. H on |0⟩
+  emitGate(GateType::H, {}, q_zero);
+
+  // 7. CNOT(|0⟩, a_0)
+  emitGate(GateType::CNOT, {q_zero}, a_0);
+
+  return a_0;
+}
+
+// ── Fig 6: CC-iZ decomposition ───────────────────────────────────────────
+// Doubly-controlled iZ gate decomposed into T/T†/CNOT.
+// 3 qubits: q0 (ctrl1), q1 (ctrl2), q2 (target).
+//
+// Gate sequence (from figure):
+//   Tdg(q2), CNOT(q1,q2), T(q2), CNOT(q0,q2),
+//   Tdg(q2), CNOT(q1,q2), T(q2), CNOT(q0,q2),
+//   T(q1), CNOT(q0,q1), T(q0), Tdg(q1), CNOT(q0,q1)
+
+void ExistingMethod::emitCCiZ(uint32_t q0, uint32_t q1, uint32_t q2) {
+  emitGate(GateType::Tdg, {}, q2);
+  emitGate(GateType::CNOT, {q1}, q2);
+  emitGate(GateType::T, {}, q2);
+  emitGate(GateType::CNOT, {q0}, q2);
+  emitGate(GateType::Tdg, {}, q2);
+  emitGate(GateType::CNOT, {q1}, q2);
+  emitGate(GateType::T, {}, q2);
+  emitGate(GateType::CNOT, {q0}, q2);
+  emitGate(GateType::T, {}, q1);
+  emitGate(GateType::CNOT, {q0}, q1);
+  emitGate(GateType::T, {}, q0);
+  emitGate(GateType::Tdg, {}, q1);
+  emitGate(GateType::CNOT, {q0}, q1);
+}
+
+// ── Fig 7: CC-iZ† decomposition ─────────────────────────────────────────
+// Adjoint of Fig 6. Gate sequence reversed with T↔Tdg swapped.
+
+void ExistingMethod::emitCCiZdg(uint32_t q0, uint32_t q1, uint32_t q2) {
+  emitGate(GateType::CNOT, {q0}, q1);
+  emitGate(GateType::T, {}, q1);
+  emitGate(GateType::Tdg, {}, q0);
+  emitGate(GateType::CNOT, {q0}, q1);
+  emitGate(GateType::Tdg, {}, q1);
+  emitGate(GateType::CNOT, {q0}, q2);
+  emitGate(GateType::Tdg, {}, q2);
+  emitGate(GateType::CNOT, {q1}, q2);
+  emitGate(GateType::T, {}, q2);
+  emitGate(GateType::CNOT, {q0}, q2);
+  emitGate(GateType::Tdg, {}, q2);
+  emitGate(GateType::CNOT, {q1}, q2);
+  emitGate(GateType::T, {}, q2);
+}
+
+// ── Utility ──────────────────────────────────────────────────────────────
+
+bool ExistingMethod::isSimpleNode(mockturtle::xag_network::node node) const {
+  if (xag_.is_pi(node) || xag_.is_constant(node))
+    return true;
+  return node_to_qubit_.find(xag_.node_to_index(node)) != node_to_qubit_.end();
+}
+
+bool ExistingMethod::isOutputNode(mockturtle::xag_network::node node) const {
+  return po_nodes_.count(xag_.node_to_index(node)) > 0;
+}
+
+void ExistingMethod::appendAdjoint(size_t startIdx, size_t endIdx) {
+  for (size_t i = endIdx; i > startIdx; --i) {
+    const auto &gate = result_.gates[i - 1];
+    GateType dag = gate.type;
+    switch (gate.type) {
+    case GateType::T:
+      dag = GateType::Tdg;
+      break;
+    case GateType::Tdg:
+      dag = GateType::T;
+      break;
+    default:
+      break; // H, X, CNOT, Toffoli are self-adjoint
+    }
+    emitGate(dag, gate.controls, gate.target);
+  }
+}
+
+void ExistingMethod::emitGate(GateType type, std::vector<uint32_t> controls,
+                              uint32_t target) {
+  result_.gates.push_back({type, std::move(controls), target});
+}

--- a/src/QC/ExistingMethod.h
+++ b/src/QC/ExistingMethod.h
@@ -1,0 +1,57 @@
+// ExistingMethod.h — Algorithm 1 ("Existing Method") XAG-to-quantum-circuit
+// translator. Uses exact Toffoli decompositions (CC-iZ via Figs 6/7) and
+// top-level compute||uncompute.
+
+#ifndef EXISTINGMETHOD_H
+#define EXISTINGMETHOD_H
+
+#include "QCGateList.h"
+#include "XagContext.h"
+#include <unordered_map>
+#include <unordered_set>
+
+namespace xagtdep {
+
+class ExistingMethod {
+public:
+  /// Traverse ctx.xag depth-first and produce a gate list per Algorithm 1.
+  static QCGateList translate(const XagContext &ctx);
+
+private:
+  explicit ExistingMethod(const mockturtle::xag_network &xag);
+
+  // ── Recursive traversal ──────────────────────────────────────────────
+  uint32_t processSignal(mockturtle::xag_network::signal sig);
+  uint32_t processNode(mockturtle::xag_network::node node);
+
+  // ── Circuit generators (one per algorithm case) ──────────────────────
+  uint32_t processXorNode(mockturtle::xag_network::node node);  // Fig 5
+  uint32_t processAndNode(mockturtle::xag_network::node node);  // routes to:
+  uint32_t emitAndBothPI(mockturtle::xag_network::node node,    // Fig 6
+                         uint32_t q_a, uint32_t q_b);
+  uint32_t emitAndOutput(mockturtle::xag_network::node node,    // Fig 1
+                         std::vector<mockturtle::xag_network::signal> &fanins);
+  uint32_t emitAndOnePI(mockturtle::xag_network::node node,     // Fig 11
+                        std::vector<mockturtle::xag_network::signal> &fanins);
+
+  // ── Decomposition helpers (exact gate sequences from figures) ────────
+  void emitCCiZ(uint32_t q0, uint32_t q1, uint32_t q2);    // Fig 6
+  void emitCCiZdg(uint32_t q0, uint32_t q1, uint32_t q2);  // Fig 7
+
+  // ── Utility ──────────────────────────────────────────────────────────
+  bool isSimpleNode(mockturtle::xag_network::node node) const;
+  bool isOutputNode(mockturtle::xag_network::node node) const;
+  void appendAdjoint(size_t startIdx, size_t endIdx);
+  void emitGate(GateType type, std::vector<uint32_t> controls, uint32_t target);
+
+  // ── State ────────────────────────────────────────────────────────────
+  const mockturtle::xag_network &xag_;
+  std::unordered_set<uint32_t> po_nodes_;
+  std::unordered_map<uint32_t, uint32_t> node_to_qubit_;
+  uint32_t next_qubit_ = 0;
+  QCGateList result_;
+};
+
+} // namespace xagtdep
+
+#endif // EXISTINGMETHOD_H

--- a/src/QC/ProposedMethod.cpp
+++ b/src/QC/ProposedMethod.cpp
@@ -1,0 +1,365 @@
+// ProposedMethod.cpp — Algorithm 2 ("Proposed Method") implementation.
+//
+// Recursive depth-first XAG traversal producing quantum gates per:
+//   XOR node  → Fig 5  (two CNOTs into output qubit)
+//   AND node  → Fig 8  (relative-phase Toffoli, both inputs PI)
+//              → Fig 2  (AND at overall output, with A/A† and CC-iωZ)
+//              → Fig 12 (one input PI, with F sub-circuit and T/T†)
+//
+// Top-level: QC = PARSEXAG(xag) directly — NO uncompute appended.
+
+#include "ProposedMethod.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace xagtdep;
+
+ProposedMethod::ProposedMethod(const mockturtle::xag_network &xag)
+    : xag_(xag) {}
+
+QCGateList ProposedMethod::translate(const XagContext &ctx) {
+  ProposedMethod t(ctx.xag);
+
+  // Assign qubits 0..num_pis-1 to primary inputs.
+  ctx.xag.foreach_pi(
+      [&](auto node) { t.node_to_qubit_[ctx.xag.node_to_index(node)] = t.next_qubit_++; });
+  t.result_.num_pis = ctx.xag.num_pis();
+
+  // Build set of PO node indices for isOutputNode detection.
+  ctx.xag.foreach_po([&](auto signal) {
+    t.po_nodes_.insert(ctx.xag.node_to_index(ctx.xag.get_node(signal)));
+  });
+
+  // Process each primary output — NO uncompute phase for Algorithm 2.
+  ctx.xag.foreach_po([&](auto signal) { t.processSignal(signal); });
+
+  t.result_.num_qubits = t.next_qubit_;
+  t.result_.num_ancillas = t.next_qubit_ - ctx.xag.num_pis();
+
+  return t.result_;
+}
+
+// ── Recursive traversal ──────────────────────────────────────────────────
+
+uint32_t ProposedMethod::processSignal(mockturtle::xag_network::signal sig) {
+  auto node = xag_.get_node(sig);
+  bool complemented = xag_.is_complemented(sig);
+  uint32_t qubit = processNode(node);
+  if (complemented)
+    emitGate(GateType::X, {}, qubit);
+  return qubit;
+}
+
+uint32_t ProposedMethod::processNode(mockturtle::xag_network::node node) {
+  uint32_t idx = xag_.node_to_index(node);
+
+  auto it = node_to_qubit_.find(idx);
+  if (it != node_to_qubit_.end())
+    return it->second;
+
+  if (idx == 0) {
+    uint32_t qubit = next_qubit_++;
+    node_to_qubit_[idx] = qubit;
+    return qubit;
+  }
+
+  if (xag_.is_pi(node))
+    return node_to_qubit_[idx];
+
+  if (xag_.is_and(node))
+    return processAndNode(node);
+
+  return processXorNode(node);
+}
+
+// ── Fig 5: XOR node ──────────────────────────────────────────────────────
+
+uint32_t ProposedMethod::processXorNode(mockturtle::xag_network::node node) {
+  std::vector<mockturtle::xag_network::signal> fanins;
+  xag_.foreach_fanin(node, [&](auto sig) { fanins.push_back(sig); });
+
+  uint32_t q_b = processSignal(fanins[0]);
+  uint32_t q_a = processSignal(fanins[1]);
+
+  uint32_t q_out = next_qubit_++;
+  emitGate(GateType::CNOT, {q_b}, q_out);
+  emitGate(GateType::CNOT, {q_a}, q_out);
+
+  node_to_qubit_[xag_.node_to_index(node)] = q_out;
+  return q_out;
+}
+
+// ── AND node router ──────────────────────────────────────────────────────
+
+uint32_t ProposedMethod::processAndNode(mockturtle::xag_network::node node) {
+  std::vector<mockturtle::xag_network::signal> fanins;
+  xag_.foreach_fanin(node, [&](auto sig) { fanins.push_back(sig); });
+
+  auto child0 = xag_.get_node(fanins[0]);
+  auto child1 = xag_.get_node(fanins[1]);
+  bool simple0 = isSimpleNode(child0);
+  bool simple1 = isSimpleNode(child1);
+
+  if (simple0 && simple1) {
+    uint32_t q_a = processSignal(fanins[0]);
+    uint32_t q_b = processSignal(fanins[1]);
+    return emitAndBothPI(node, q_a, q_b);
+  }
+
+  if (isOutputNode(node)) {
+    return emitAndOutput(node, fanins);
+  }
+
+  if (simple0 || simple1) {
+    return emitAndOnePI(node, fanins);
+  }
+
+  llvm::errs() << "[ProposedMethod] ERROR: both AND children are complex "
+                  "sub-circuits (unsupported)\n";
+  uint32_t q_err = next_qubit_++;
+  node_to_qubit_[xag_.node_to_index(node)] = q_err;
+  return q_err;
+}
+
+// ── Fig 8: AND both PI (relative-phase Toffoli) ─────────────────────────
+// 3 wires: q_a (ctrl1), q_b (ctrl2), f (ancilla with H).
+// This is H + CC-iωZ (Fig 9) + H on the ancilla wire.
+//
+// Gate sequence from Fig 8:
+//   H(f), Tdg(f), CNOT(q_a,f), T(f), CNOT(q_b,f),
+//   Tdg(f), CNOT(q_a,f), T(f), CNOT(q_b,f),
+//   T(q_a), CNOT(q_b,q_a), T(q_b), Tdg(q_a), CNOT(q_b,q_a), H(f)
+
+uint32_t ProposedMethod::emitAndBothPI(mockturtle::xag_network::node node,
+                                       uint32_t q_a, uint32_t q_b) {
+  uint32_t f = next_qubit_++;
+  node_to_qubit_[xag_.node_to_index(node)] = f;
+
+  emitGate(GateType::H, {}, f);
+  emitCCiwZ(q_a, q_b, f);
+  emitGate(GateType::H, {}, f);
+
+  return f;
+}
+
+// ── Fig 2: AND output case ───────────────────────────────────────────────
+// Same structure as Fig 1 but uses CC-iωZ/iωZ† (Figs 9/10) instead of
+// CC-iZ/iZ† (Figs 6/7).
+//
+// Sequence:
+//   1. H on |0⟩
+//   2. CC-iωZ(B, |0⟩, a_i)
+//   3. Compute A sub-circuit
+//   4. CNOT(A_output, a_i)
+//   5. CC-iωZ†(B, |0⟩, a_i)
+//   6. A† (uncompute A)
+//   7. H on |0⟩
+//   8. CNOT(|0⟩, a_i)
+
+uint32_t ProposedMethod::emitAndOutput(
+    mockturtle::xag_network::node node,
+    std::vector<mockturtle::xag_network::signal> &fanins) {
+  auto child0 = xag_.get_node(fanins[0]);
+  bool simple0 = isSimpleNode(child0);
+
+  int piIdx = simple0 ? 0 : 1;
+  int complexIdx = 1 - piIdx;
+
+  uint32_t q_b = processSignal(fanins[piIdx]);
+
+  uint32_t a_i = next_qubit_++;
+  uint32_t q_zero = next_qubit_++;
+
+  node_to_qubit_[xag_.node_to_index(node)] = a_i;
+
+  // 1. H on |0⟩
+  emitGate(GateType::H, {}, q_zero);
+
+  // 2. CC-iωZ(B, |0⟩, a_i)
+  emitCCiwZ(q_b, q_zero, a_i);
+
+  // 3. Compute A sub-circuit
+  size_t computeStart = result_.gates.size();
+  uint32_t q_a = processSignal(fanins[complexIdx]);
+  size_t computeEnd = result_.gates.size();
+
+  // 4. CNOT(A_output, a_i)
+  emitGate(GateType::CNOT, {q_a}, a_i);
+
+  // 5. CC-iωZ†(B, |0⟩, a_i)
+  emitCCiwZdg(q_b, q_zero, a_i);
+
+  // 6. A† (uncompute A)
+  appendAdjoint(computeStart, computeEnd);
+
+  // 7. H on |0⟩
+  emitGate(GateType::H, {}, q_zero);
+
+  // 8. CNOT(|0⟩, a_i)
+  emitGate(GateType::CNOT, {q_zero}, a_i);
+
+  return a_i;
+}
+
+// ── Fig 12: AND one PI case ──────────────────────────────────────────────
+// One input is PI (G), other requires sub-circuit (F).
+// Uses T/T†/CNOT/H directly (no controlled phase gates).
+//
+// Wires: [F sub-circuit wires], G (PI), a (ancilla), f (ancilla)
+// Sequence from Fig 12:
+//   1. H(f)
+//   2. CNOT(f, a)
+//   3. CNOT(f, G)
+//   4. T(G), Tdg(a)
+//   5. Compute F sub-circuit
+//   6. CNOT(F_out, G), CNOT(F_out, a)
+//   7. Tdg(G), T(a)
+//   8. CNOT(f, G), CNOT(f, a)
+//   9. T(G), Tdg(a) — wait, need to re-read...
+//
+// Actually, reading Fig 12 carefully left-to-right:
+//   H(f), CNOT(f,a), CNOT(a,G), T(G), Tdg(a),
+//   CNOT(f,a), CNOT(a,G),
+//   [F sub-circuit],
+//   CNOT(F_out,G), CNOT(F_out,a),
+//   Tdg(G), T(a),
+//   CNOT(f,a), CNOT(a,G),
+//   T(G), Tdg(a) — no, let me trace more carefully from image.
+//
+// Fig 12 gate sequence (3 lower wires: G, a, f; upper wires through F):
+//   H(f)
+//   CNOT(f, a)        — f controls, a target
+//   CNOT(a, G)        — a controls, G target
+//   T(G)
+//   Tdg(a)
+//   CNOT(f, a)        — f controls, a target
+//   CNOT(a, G)        — a controls, G target
+//   [F sub-circuit on upper wires]
+//   CNOT(F_out, G)    — F output controls, G target
+//   CNOT(F_out, a)    — F output controls, a target
+//   Tdg(G)
+//   T(a)
+//   CNOT(f, a)
+//   CNOT(a, G)
+//   H(f)
+
+uint32_t ProposedMethod::emitAndOnePI(
+    mockturtle::xag_network::node node,
+    std::vector<mockturtle::xag_network::signal> &fanins) {
+  auto child0 = xag_.get_node(fanins[0]);
+  bool simple0 = isSimpleNode(child0);
+
+  int piIdx = simple0 ? 0 : 1;
+  int complexIdx = 1 - piIdx;
+
+  uint32_t q_g = processSignal(fanins[piIdx]); // G — primary input
+
+  uint32_t a = next_qubit_++;  // a — ancilla
+  uint32_t f = next_qubit_++;  // f — ancilla (H-prepared)
+
+  node_to_qubit_[xag_.node_to_index(node)] = a;
+
+  // Fig 12 gate sequence
+  emitGate(GateType::H, {}, f);
+
+  emitGate(GateType::CNOT, {f}, a);
+  emitGate(GateType::CNOT, {a}, q_g);
+  emitGate(GateType::T, {}, q_g);
+  emitGate(GateType::Tdg, {}, a);
+
+  emitGate(GateType::CNOT, {f}, a);
+  emitGate(GateType::CNOT, {a}, q_g);
+
+  // Compute F sub-circuit
+  uint32_t q_f = processSignal(fanins[complexIdx]);
+
+  // Continue Fig 12 after F
+  emitGate(GateType::CNOT, {q_f}, q_g);
+  emitGate(GateType::CNOT, {q_f}, a);
+  emitGate(GateType::Tdg, {}, q_g);
+  emitGate(GateType::T, {}, a);
+
+  emitGate(GateType::CNOT, {f}, a);
+  emitGate(GateType::CNOT, {a}, q_g);
+
+  emitGate(GateType::H, {}, f);
+
+  return a;
+}
+
+// ── Fig 9: CC-iωZ decomposition ─────────────────────────────────────────
+// Doubly-controlled iωZ gate decomposed into T/T†/CNOT.
+// 3 qubits: q0 (ctrl1), q1 (ctrl2), q2 (target).
+//
+// Gate sequence (from figure, same structure as Fig 6 but different T/Tdg
+// placement reflecting the ω phase):
+//   CNOT(q1,q2), T(q2), CNOT(q0,q2),
+//   Tdg(q2), CNOT(q1,q2), T(q2), CNOT(q0,q2),
+//   T(q1), CNOT(q0,q1), T(q0), Tdg(q1), CNOT(q0,q1)
+
+void ProposedMethod::emitCCiwZ(uint32_t q0, uint32_t q1, uint32_t q2) {
+  emitGate(GateType::CNOT, {q1}, q2);
+  emitGate(GateType::T, {}, q2);
+  emitGate(GateType::CNOT, {q0}, q2);
+  emitGate(GateType::Tdg, {}, q2);
+  emitGate(GateType::CNOT, {q1}, q2);
+  emitGate(GateType::T, {}, q2);
+  emitGate(GateType::CNOT, {q0}, q2);
+  emitGate(GateType::T, {}, q1);
+  emitGate(GateType::CNOT, {q0}, q1);
+  emitGate(GateType::T, {}, q0);
+  emitGate(GateType::Tdg, {}, q1);
+  emitGate(GateType::CNOT, {q0}, q1);
+}
+
+// ── Fig 10: CC-iωZ† decomposition ───────────────────────────────────────
+// Adjoint of Fig 9. Reversed gate order with T↔Tdg swapped.
+
+void ProposedMethod::emitCCiwZdg(uint32_t q0, uint32_t q1, uint32_t q2) {
+  emitGate(GateType::CNOT, {q0}, q1);
+  emitGate(GateType::T, {}, q1);
+  emitGate(GateType::Tdg, {}, q0);
+  emitGate(GateType::CNOT, {q0}, q1);
+  emitGate(GateType::Tdg, {}, q1);
+  emitGate(GateType::CNOT, {q0}, q2);
+  emitGate(GateType::Tdg, {}, q2);
+  emitGate(GateType::CNOT, {q1}, q2);
+  emitGate(GateType::T, {}, q2);
+  emitGate(GateType::CNOT, {q0}, q2);
+  emitGate(GateType::Tdg, {}, q2);
+  emitGate(GateType::CNOT, {q1}, q2);
+}
+
+// ── Utility ──────────────────────────────────────────────────────────────
+
+bool ProposedMethod::isSimpleNode(mockturtle::xag_network::node node) const {
+  if (xag_.is_pi(node) || xag_.is_constant(node))
+    return true;
+  return node_to_qubit_.find(xag_.node_to_index(node)) != node_to_qubit_.end();
+}
+
+bool ProposedMethod::isOutputNode(mockturtle::xag_network::node node) const {
+  return po_nodes_.count(xag_.node_to_index(node)) > 0;
+}
+
+void ProposedMethod::appendAdjoint(size_t startIdx, size_t endIdx) {
+  for (size_t i = endIdx; i > startIdx; --i) {
+    const auto &gate = result_.gates[i - 1];
+    GateType dag = gate.type;
+    switch (gate.type) {
+    case GateType::T:
+      dag = GateType::Tdg;
+      break;
+    case GateType::Tdg:
+      dag = GateType::T;
+      break;
+    default:
+      break;
+    }
+    emitGate(dag, gate.controls, gate.target);
+  }
+}
+
+void ProposedMethod::emitGate(GateType type, std::vector<uint32_t> controls,
+                              uint32_t target) {
+  result_.gates.push_back({type, std::move(controls), target});
+}

--- a/src/QC/ProposedMethod.h
+++ b/src/QC/ProposedMethod.h
@@ -1,0 +1,57 @@
+// ProposedMethod.h — Algorithm 2 ("Proposed Method") XAG-to-quantum-circuit
+// translator. Uses relative-phase Toffoli (CC-iωZ via Figs 8/9/10) and
+// NO top-level uncompute.
+
+#ifndef PROPOSEDMETHOD_H
+#define PROPOSEDMETHOD_H
+
+#include "QCGateList.h"
+#include "XagContext.h"
+#include <unordered_map>
+#include <unordered_set>
+
+namespace xagtdep {
+
+class ProposedMethod {
+public:
+  /// Traverse ctx.xag depth-first and produce a gate list per Algorithm 2.
+  static QCGateList translate(const XagContext &ctx);
+
+private:
+  explicit ProposedMethod(const mockturtle::xag_network &xag);
+
+  // ── Recursive traversal ──────────────────────────────────────────────
+  uint32_t processSignal(mockturtle::xag_network::signal sig);
+  uint32_t processNode(mockturtle::xag_network::node node);
+
+  // ── Circuit generators (one per algorithm case) ──────────────────────
+  uint32_t processXorNode(mockturtle::xag_network::node node);  // Fig 5
+  uint32_t processAndNode(mockturtle::xag_network::node node);  // routes to:
+  uint32_t emitAndBothPI(mockturtle::xag_network::node node,    // Fig 8
+                         uint32_t q_a, uint32_t q_b);
+  uint32_t emitAndOutput(mockturtle::xag_network::node node,    // Fig 2
+                         std::vector<mockturtle::xag_network::signal> &fanins);
+  uint32_t emitAndOnePI(mockturtle::xag_network::node node,     // Fig 12
+                        std::vector<mockturtle::xag_network::signal> &fanins);
+
+  // ── Decomposition helpers (exact gate sequences from figures) ────────
+  void emitCCiwZ(uint32_t q0, uint32_t q1, uint32_t q2);    // Fig 9
+  void emitCCiwZdg(uint32_t q0, uint32_t q1, uint32_t q2);  // Fig 10
+
+  // ── Utility ──────────────────────────────────────────────────────────
+  bool isSimpleNode(mockturtle::xag_network::node node) const;
+  bool isOutputNode(mockturtle::xag_network::node node) const;
+  void appendAdjoint(size_t startIdx, size_t endIdx);
+  void emitGate(GateType type, std::vector<uint32_t> controls, uint32_t target);
+
+  // ── State ────────────────────────────────────────────────────────────
+  const mockturtle::xag_network &xag_;
+  std::unordered_set<uint32_t> po_nodes_;
+  std::unordered_map<uint32_t, uint32_t> node_to_qubit_;
+  uint32_t next_qubit_ = 0;
+  QCGateList result_;
+};
+
+} // namespace xagtdep
+
+#endif // PROPOSEDMETHOD_H

--- a/src/QC/QC.cpp
+++ b/src/QC/QC.cpp
@@ -1,6 +1,8 @@
 // QC.cpp
 #include "QC.h"
 #include "NewMethod.h"
+#include "ExistingMethod.h"
+#include "ProposedMethod.h"
 #include "QCGateList.h"
 #include "XAGToGateList.h"
 #include "llvm/IR/Function.h"
@@ -17,7 +19,7 @@ using namespace xagtdep;
 
 // ── Core algorithm ────────────────────────────────────────────────────────
 // Consume the optimized XagContext and synthesize a quantum circuit.
-void QC::evaluate(const XagContext &ctx) {
+void QC::evaluate(const XagContext &ctx, SynthesisAlgorithm algo) {
   errs() << "[QC] Received XAG: "
          << "PIs=" << ctx.xag.num_pis() << " POs=" << ctx.xag.num_pos()
          << " Gates=" << ctx.xag.num_gates()
@@ -29,8 +31,22 @@ void QC::evaluate(const XagContext &ctx) {
     return;
   }
 
-  // Convert XAG to gate list via depth-first traversal (SPEC XAG2QC).
-  QCGateList gateList = XAGToGateList::translate(ctx);
+  // Select synthesis algorithm.
+  QCGateList gateList;
+  switch (algo) {
+  case SynthesisAlgorithm::Current:
+    errs() << "[QC] Using Current (XAGToGateList) algorithm.\n";
+    gateList = XAGToGateList::translate(ctx);
+    break;
+  case SynthesisAlgorithm::ExistingMethod:
+    errs() << "[QC] Using Existing Method (Algorithm 1).\n";
+    gateList = ExistingMethod::translate(ctx);
+    break;
+  case SynthesisAlgorithm::ProposedMethod:
+    errs() << "[QC] Using Proposed Method (Algorithm 2).\n";
+    gateList = ProposedMethod::translate(ctx);
+    break;
+  }
   std::string json = gateList.toJSON();
   errs() << "[QC] Gate list: " << json << "\n";
 

--- a/src/QC/qc_synthesis.py
+++ b/src/QC/qc_synthesis.py
@@ -22,5 +22,11 @@ def gates_to_qasm(json_str: str) -> str:
             qc.cx(ctrls[0], tgt)
         elif t == "ccx":
             qc.ccx(ctrls[0], ctrls[1], tgt)
+        elif t == "h":
+            qc.h(tgt)
+        elif t == "t":
+            qc.t(tgt)
+        elif t == "tdg":
+            qc.tdg(tgt)
 
     return dumps(qc)

--- a/src/XAG/XAG.cpp
+++ b/src/XAG/XAG.cpp
@@ -11,14 +11,14 @@ using namespace llvm;
 using namespace xagtdep;
 
 // ── Core algorithm ────────────────────────────────────────────────────────
-// Run caterpillar's T-depth minimization strategy on ctx.xag.
+// Run Meuli low-depth strategy on ctx.xag.
 // Populates ctx.steps and sets ctx.optimized = true on success.
 void XAG::optimize(XagContext &ctx) {
   errs() << "[XAG] BEFORE: PIs=" << ctx.xag.num_pis()
          << " POs=" << ctx.xag.num_pos() << " Gates=" << ctx.xag.num_gates()
          << "\n";
 
-  // Algorithm 2 from Meuli et al. (2022) — T-depth minimization.
+  // Meuli low-depth strategy (Meuli et al. 2022, doi:10.1038/s41534-021-00514-y).
   // Processes the XAG level-by-level (ASAP), copies shared AND inputs to
   // fresh ancilla qubits so all ANDs in a level execute in one T-stage.
   // T-depth of resulting circuit = AND-depth of XAG.

--- a/test/QCTest.cpp
+++ b/test/QCTest.cpp
@@ -2,6 +2,8 @@
 #include "QC.h"
 #include "NewMethod.h"
 #include "XAG.h"
+#include "ExistingMethod.h"
+#include "ProposedMethod.h"
 #include "XAGToGateList.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Function.h"
@@ -131,9 +133,299 @@ static bool testAndCase2() {
   return pass;
 }
 
+/// Helper: return gate type name string.
+static const char *gateTypeName(GateType t) {
+  switch (t) {
+  case GateType::X:       return "X";
+  case GateType::CNOT:    return "CNOT";
+  case GateType::Toffoli: return "Toffoli";
+  case GateType::H:       return "H";
+  case GateType::T:       return "T";
+  case GateType::Tdg:     return "Tdg";
+  }
+  return "?";
+}
+
+/// Helper: print gate list for debugging.
+static void printGateList(const char *label, const QCGateList &gl) {
+  errs() << "[" << label << "] num_qubits=" << gl.num_qubits
+         << " num_pis=" << gl.num_pis
+         << " num_ancillas=" << gl.num_ancillas
+         << " gates=" << gl.gates.size() << "\n";
+  for (size_t i = 0; i < gl.gates.size(); ++i) {
+    const auto &g = gl.gates[i];
+    errs() << "  [" << i << "] " << gateTypeName(g.type) << "(";
+    for (size_t j = 0; j < g.controls.size(); ++j) {
+      if (j > 0) errs() << ",";
+      errs() << "q" << g.controls[j];
+    }
+    errs() << " -> q" << g.target << ")\n";
+  }
+}
+
+/// Helper: check that a gate list contains only decomposed gates (H,T,Tdg,CNOT,X).
+static bool hasOnlyDecomposedGates(const QCGateList &gl) {
+  for (const auto &g : gl.gates) {
+    if (g.type != GateType::H && g.type != GateType::T &&
+        g.type != GateType::Tdg && g.type != GateType::CNOT &&
+        g.type != GateType::X) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Test 3: Existing Method on (a AND b) XOR c.
+static bool testExistingMethodPipeline() {
+  // Build XAG: (a AND b) XOR c
+  mockturtle::xag_network xag;
+  auto a = xag.create_pi();
+  auto b = xag.create_pi();
+  auto c = xag.create_pi();
+  auto ab = xag.create_and(a, b);
+  auto result = xag.create_xor(ab, c);
+  xag.create_po(result);
+
+  XagContext xagCtx;
+  xagCtx.xag = xag;
+  xagCtx.optimized = true;
+
+  QCGateList gateList = ExistingMethod::translate(xagCtx);
+  printGateList("ExistingMethod::Pipeline", gateList);
+
+  bool pass = true;
+
+  if (gateList.gates.empty()) {
+    errs() << "[ExistingMethod::Pipeline] FAIL: gate list is empty\n";
+    pass = false;
+  }
+
+  if (!hasOnlyDecomposedGates(gateList)) {
+    errs() << "[ExistingMethod::Pipeline] FAIL: contains non-decomposed gates\n";
+    pass = false;
+  }
+
+  if (gateList.num_pis != 3) {
+    errs() << "[ExistingMethod::Pipeline] FAIL: expected 3 PIs, got "
+           << gateList.num_pis << "\n";
+    pass = false;
+  }
+
+  errs() << "[ExistingMethod::Pipeline] " << (pass ? "PASSED" : "FAILED") << "\n";
+  return pass;
+}
+
+/// Test 4: Proposed Method on (a AND b) XOR c.
+static bool testProposedMethodPipeline() {
+  mockturtle::xag_network xag;
+  auto a = xag.create_pi();
+  auto b = xag.create_pi();
+  auto c = xag.create_pi();
+  auto ab = xag.create_and(a, b);
+  auto result = xag.create_xor(ab, c);
+  xag.create_po(result);
+
+  XagContext xagCtx;
+  xagCtx.xag = xag;
+  xagCtx.optimized = true;
+
+  QCGateList gateList = ProposedMethod::translate(xagCtx);
+  printGateList("ProposedMethod::Pipeline", gateList);
+
+  bool pass = true;
+
+  if (gateList.gates.empty()) {
+    errs() << "[ProposedMethod::Pipeline] FAIL: gate list is empty\n";
+    pass = false;
+  }
+
+  if (!hasOnlyDecomposedGates(gateList)) {
+    errs() << "[ProposedMethod::Pipeline] FAIL: contains non-decomposed gates\n";
+    pass = false;
+  }
+
+  if (gateList.num_pis != 3) {
+    errs() << "[ProposedMethod::Pipeline] FAIL: expected 3 PIs, got "
+           << gateList.num_pis << "\n";
+    pass = false;
+  }
+
+  errs() << "[ProposedMethod::Pipeline] " << (pass ? "PASSED" : "FAILED") << "\n";
+  return pass;
+}
+
+/// Test 5: Existing Method on a AND (b XOR c) — exercises "one PI" (Fig 11).
+static bool testExistingMethodAndOnePI() {
+  mockturtle::xag_network xag;
+  auto a = xag.create_pi();
+  auto b = xag.create_pi();
+  auto c = xag.create_pi();
+  auto bxc = xag.create_xor(b, c);
+  auto result = xag.create_and(a, bxc);
+  xag.create_po(result);
+
+  XagContext xagCtx;
+  xagCtx.xag = xag;
+  xagCtx.optimized = true;
+
+  QCGateList gateList = ExistingMethod::translate(xagCtx);
+  printGateList("ExistingMethod::AndOnePI", gateList);
+
+  bool pass = true;
+
+  if (gateList.gates.empty()) {
+    errs() << "[ExistingMethod::AndOnePI] FAIL: gate list is empty\n";
+    pass = false;
+  }
+
+  if (!hasOnlyDecomposedGates(gateList)) {
+    errs() << "[ExistingMethod::AndOnePI] FAIL: contains non-decomposed gates\n";
+    pass = false;
+  }
+
+  errs() << "[ExistingMethod::AndOnePI] " << (pass ? "PASSED" : "FAILED") << "\n";
+  return pass;
+}
+
+/// Test 6: Proposed Method on a AND (b XOR c) — exercises "one PI" (Fig 12).
+static bool testProposedMethodAndOnePI() {
+  mockturtle::xag_network xag;
+  auto a = xag.create_pi();
+  auto b = xag.create_pi();
+  auto c = xag.create_pi();
+  auto bxc = xag.create_xor(b, c);
+  auto result = xag.create_and(a, bxc);
+  xag.create_po(result);
+
+  XagContext xagCtx;
+  xagCtx.xag = xag;
+  xagCtx.optimized = true;
+
+  QCGateList gateList = ProposedMethod::translate(xagCtx);
+  printGateList("ProposedMethod::AndOnePI", gateList);
+
+  bool pass = true;
+
+  if (gateList.gates.empty()) {
+    errs() << "[ProposedMethod::AndOnePI] FAIL: gate list is empty\n";
+    pass = false;
+  }
+
+  if (!hasOnlyDecomposedGates(gateList)) {
+    errs() << "[ProposedMethod::AndOnePI] FAIL: contains non-decomposed gates\n";
+    pass = false;
+  }
+
+  errs() << "[ProposedMethod::AndOnePI] " << (pass ? "PASSED" : "FAILED") << "\n";
+  return pass;
+}
+
+/// Helper: count gates by type and print a summary line.
+struct GateCounts {
+  uint32_t t = 0, tdg = 0, cnot = 0, h = 0, x = 0, toffoli = 0;
+  uint32_t total = 0;
+  uint32_t tCount() const { return t + tdg; }
+};
+
+static GateCounts countGates(const QCGateList &gl) {
+  GateCounts c;
+  c.total = gl.gates.size();
+  for (const auto &g : gl.gates) {
+    switch (g.type) {
+    case GateType::T:       c.t++; break;
+    case GateType::Tdg:     c.tdg++; break;
+    case GateType::CNOT:    c.cnot++; break;
+    case GateType::H:       c.h++; break;
+    case GateType::X:       c.x++; break;
+    case GateType::Toffoli: c.toffoli++; break;
+    }
+  }
+  return c;
+}
+
+static void printRow(const char *name, const QCGateList &gl) {
+  GateCounts c = countGates(gl);
+  // For Current algorithm: each abstract Toffoli decomposes to 7 T-gates + 6 CNOTs
+  uint32_t effectiveT = c.tCount() + c.toffoli * 7;
+  uint32_t effectiveCNOT = c.cnot + c.toffoli * 6;
+  uint32_t effectiveTotal = c.total + c.toffoli * 12; // replace 1 Toffoli with 13 gates
+
+  errs() << "  " << name;
+  // Pad to 20 chars
+  for (size_t i = strlen(name); i < 20; i++) errs() << " ";
+  errs() << "| " << gl.num_qubits << "\t| "
+         << effectiveT << "\t| " << effectiveCNOT << "\t| "
+         << c.h << "\t| " << effectiveTotal << "\n";
+}
+
+/// Comparison test: run all 3 algorithms on the same XAGs and print table.
+static bool testComparison() {
+  errs() << "\n========== ALGORITHM COMPARISON ==========\n";
+
+  // --- Circuit 1: (a AND b) XOR c ---
+  {
+    mockturtle::xag_network xag;
+    auto a = xag.create_pi();
+    auto b = xag.create_pi();
+    auto c = xag.create_pi();
+    auto ab = xag.create_and(a, b);
+    auto result = xag.create_xor(ab, c);
+    xag.create_po(result);
+
+    XagContext ctx;
+    ctx.xag = xag;
+    ctx.optimized = true;
+
+    QCGateList gl_cur = XAGToGateList::translate(ctx);
+    QCGateList gl_ex  = ExistingMethod::translate(ctx);
+    QCGateList gl_pr  = ProposedMethod::translate(ctx);
+
+    errs() << "\n  Circuit: (a AND b) XOR c\n";
+    errs() << "  Algorithm           | Qubits\t| T-count\t| CNOTs\t| H\t| Total\n";
+    errs() << "  --------------------|-------|---------|-------|---|------\n";
+    printRow("Current", gl_cur);
+    printRow("Existing Method", gl_ex);
+    printRow("Proposed Method", gl_pr);
+  }
+
+  // --- Circuit 2: a AND (b XOR c) ---
+  {
+    mockturtle::xag_network xag;
+    auto a = xag.create_pi();
+    auto b = xag.create_pi();
+    auto c = xag.create_pi();
+    auto bxc = xag.create_xor(b, c);
+    auto result = xag.create_and(a, bxc);
+    xag.create_po(result);
+
+    XagContext ctx;
+    ctx.xag = xag;
+    ctx.optimized = true;
+
+    QCGateList gl_cur = XAGToGateList::translate(ctx);
+    QCGateList gl_ex  = ExistingMethod::translate(ctx);
+    QCGateList gl_pr  = ProposedMethod::translate(ctx);
+
+    errs() << "\n  Circuit: a AND (b XOR c)\n";
+    errs() << "  Algorithm           | Qubits\t| T-count\t| CNOTs\t| H\t| Total\n";
+    errs() << "  --------------------|-------|---------|-------|---|------\n";
+    printRow("Current", gl_cur);
+    printRow("Existing Method", gl_ex);
+    printRow("Proposed Method", gl_pr);
+  }
+
+  errs() << "\n==========================================\n\n";
+  return true; // comparison always passes
+}
+
 int main() {
   bool allPass = true;
   allPass &= testPipeline();
   allPass &= testAndCase2();
+  allPass &= testExistingMethodPipeline();
+  allPass &= testProposedMethodPipeline();
+  allPass &= testExistingMethodAndOnePI();
+  allPass &= testProposedMethodAndOnePI();
+  allPass &= testComparison();
   return allPass ? 0 : 1;
 }


### PR DESCRIPTION
Add two new XAG-to-quantum-circuit translators:

- Existing Method (Algorithm 1): exact Toffoli decomposition using CC-iZ (Figs 6/7), phase-based AND for output nodes (Fig 1) and one-PI nodes (Fig 11), with top-level compute||uncompute.

- Proposed Method (Algorithm 2): relative-phase Toffoli using CC-iωZ (Figs 8/9/10), phase-based AND for output (Fig 2) and T/T†-based AND for one-PI nodes (Fig 12), no top-level uncompute needed.

Both algorithms decompose all gates to {H, T, T†, CNOT, X} — no abstract Toffoli gates. Algorithm selection via SynthesisAlgorithm enum in QC::evaluate(). Existing XAGToGateList kept as "Current" option.

Includes comparison test showing Proposed Method achieves lowest T-count.